### PR TITLE
Add `internal_token` parameter for `ds_389::instance`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -16,15 +16,15 @@
 
 ### Defined types
 
-* [`ds_389::add`](#ds_389add): Adds an ldif file to a 389 ds instance.
-* [`ds_389::backup`](#ds_389backup): Setup backup jobs for a 389 ds instance.
-* [`ds_389::instance`](#ds_389instance): Manages a 389 ds instance.
-* [`ds_389::modify`](#ds_389modify): Adds an ldif modify file to a 389 ds instance.
-* [`ds_389::plugin`](#ds_389plugin): Manages a plugin for a 389 ds instance.
-* [`ds_389::replication`](#ds_389replication): Sets up replication for a 389 ds instance.
-* [`ds_389::schema`](#ds_389schema): Adds a schema extension ldif file to a 389 ds instance.
-* [`ds_389::service`](#ds_389service): Manages the service for a 389 ds instance.
-* [`ds_389::ssl`](#ds_389ssl): Manages SSL for a 389 ds instance.
+* [`ds_389::add`](#ds_389--add): Adds an ldif file to a 389 ds instance.
+* [`ds_389::backup`](#ds_389--backup): Setup backup jobs for a 389 ds instance.
+* [`ds_389::instance`](#ds_389--instance): Manages a 389 ds instance.
+* [`ds_389::modify`](#ds_389--modify): Adds an ldif modify file to a 389 ds instance.
+* [`ds_389::plugin`](#ds_389--plugin): Manages a plugin for a 389 ds instance.
+* [`ds_389::replication`](#ds_389--replication): Sets up replication for a 389 ds instance.
+* [`ds_389::schema`](#ds_389--schema): Adds a schema extension ldif file to a 389 ds instance.
+* [`ds_389::service`](#ds_389--service): Manages the service for a 389 ds instance.
+* [`ds_389::ssl`](#ds_389--ssl): Manages SSL for a 389 ds instance.
 
 ### Tasks
 
@@ -48,135 +48,135 @@ include ds_389
 
 The following parameters are available in the `ds_389` class:
 
-* [`cacert_rehash`](#cacert_rehash)
-* [`cacerts_path`](#cacerts_path)
-* [`dnf_module_name`](#dnf_module_name)
-* [`dnf_module_version`](#dnf_module_version)
-* [`group`](#group)
-* [`home_dir`](#home_dir)
-* [`instances`](#instances)
-* [`limits_config_dir`](#limits_config_dir)
-* [`nsstools_package_name`](#nsstools_package_name)
-* [`package_ensure`](#package_ensure)
-* [`package_name`](#package_name)
-* [`path`](#path)
-* [`service_type`](#service_type)
-* [`ssl_dir`](#ssl_dir)
-* [`ssl_version_min_support`](#ssl_version_min_support)
-* [`supplier_role_name`](#supplier_role_name)
-* [`user`](#user)
-* [`user_shell`](#user_shell)
+* [`cacert_rehash`](#-ds_389--cacert_rehash)
+* [`cacerts_path`](#-ds_389--cacerts_path)
+* [`dnf_module_name`](#-ds_389--dnf_module_name)
+* [`dnf_module_version`](#-ds_389--dnf_module_version)
+* [`group`](#-ds_389--group)
+* [`home_dir`](#-ds_389--home_dir)
+* [`instances`](#-ds_389--instances)
+* [`limits_config_dir`](#-ds_389--limits_config_dir)
+* [`nsstools_package_name`](#-ds_389--nsstools_package_name)
+* [`package_ensure`](#-ds_389--package_ensure)
+* [`package_name`](#-ds_389--package_name)
+* [`path`](#-ds_389--path)
+* [`service_type`](#-ds_389--service_type)
+* [`ssl_dir`](#-ds_389--ssl_dir)
+* [`ssl_version_min_support`](#-ds_389--ssl_version_min_support)
+* [`supplier_role_name`](#-ds_389--supplier_role_name)
+* [`user`](#-ds_389--user)
+* [`user_shell`](#-ds_389--user_shell)
 
-##### <a name="cacert_rehash"></a>`cacert_rehash`
+##### <a name="-ds_389--cacert_rehash"></a>`cacert_rehash`
 
 Data type: `String`
 
 The command that is used to rehash CA certificates.
 
-##### <a name="cacerts_path"></a>`cacerts_path`
+##### <a name="-ds_389--cacerts_path"></a>`cacerts_path`
 
 Data type: `Stdlib::Absolutepath`
 
 Target directory the 389 ds certs should be exported to. Default: '/etc/openldap/cacerts'
 
-##### <a name="dnf_module_name"></a>`dnf_module_name`
+##### <a name="-ds_389--dnf_module_name"></a>`dnf_module_name`
 
 Data type: `Optional[String]`
 
 The name of the DNF module that should be enabled on RHEL. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="dnf_module_version"></a>`dnf_module_version`
+##### <a name="-ds_389--dnf_module_version"></a>`dnf_module_version`
 
 Data type: `Optional[String]`
 
 The version of the DNF module that should be enabled on RHEL. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="group"></a>`group`
+##### <a name="-ds_389--group"></a>`group`
 
 Data type: `String`
 
 Group account 389 ds user should belong to. Default: 'dirsrv'
 
-##### <a name="home_dir"></a>`home_dir`
+##### <a name="-ds_389--home_dir"></a>`home_dir`
 
 Data type: `Stdlib::Absolutepath`
 
 Home directory for the 389 ds user account. Default: '/usr/share/dirsrv'
 
-##### <a name="instances"></a>`instances`
+##### <a name="-ds_389--instances"></a>`instances`
 
 Data type: `Hash`
 
 A hash of ds_389::instance resources. Optional.
 
-##### <a name="limits_config_dir"></a>`limits_config_dir`
+##### <a name="-ds_389--limits_config_dir"></a>`limits_config_dir`
 
 Data type: `Stdlib::Absolutepath`
 
 Target directory for resource limit configuration.
 
-##### <a name="nsstools_package_name"></a>`nsstools_package_name`
+##### <a name="-ds_389--nsstools_package_name"></a>`nsstools_package_name`
 
 Data type: `String`
 
 Name of the NSS tools package.
 
-##### <a name="package_ensure"></a>`package_ensure`
+##### <a name="-ds_389--package_ensure"></a>`package_ensure`
 
 Data type: `String`
 
 389 ds package state. Default 'installed'
 
-##### <a name="package_name"></a>`package_name`
+##### <a name="-ds_389--package_name"></a>`package_name`
 
 Data type: `Variant[String,Array]`
 
 Name of the 389 ds package to install. Default: '389-ds-base'
 
-##### <a name="path"></a>`path`
+##### <a name="-ds_389--path"></a>`path`
 
 Data type: `String`
 
 Specifies the content of the PATH environment variable when running commands.
 Should usually NOT be altered.
 
-##### <a name="service_type"></a>`service_type`
+##### <a name="-ds_389--service_type"></a>`service_type`
 
 Data type: `String`
 
 The service manager that should be used.
 
-##### <a name="ssl_dir"></a>`ssl_dir`
+##### <a name="-ds_389--ssl_dir"></a>`ssl_dir`
 
 Data type: `Stdlib::Absolutepath`
 
 Target directory for generated SSL certificates.
 
-##### <a name="ssl_version_min_support"></a>`ssl_version_min_support`
+##### <a name="-ds_389--ssl_version_min_support"></a>`ssl_version_min_support`
 
 Data type: `Boolean`
 
 Obsolete parameter, only kept for compatibility with
 spacepants/puppet-ds_389. Will be removed in a later version.
 
-##### <a name="supplier_role_name"></a>`supplier_role_name`
+##### <a name="-ds_389--supplier_role_name"></a>`supplier_role_name`
 
 Data type: `String`
 
 In 389-ds the name of the supplier replication role was renamed from
 'master' to 'supplier' in a backwards-incompatible fashion (issue #4656).
 
-##### <a name="user"></a>`user`
+##### <a name="-ds_389--user"></a>`user`
 
 Data type: `String`
 
 User account 389 ds should run as. Default: 'dirsrv'
 
-##### <a name="user_shell"></a>`user_shell`
+##### <a name="-ds_389--user_shell"></a>`user_shell`
 
 Data type: `String`
 
@@ -184,7 +184,7 @@ Shell for the user account. Usually a pseudo-shell to prevent console access.
 
 ## Defined types
 
-### <a name="ds_389add"></a>`ds_389::add`
+### <a name="ds_389--add"></a>`ds_389::add`
 
 Adds an ldif file to a 389 ds instance.
 
@@ -231,27 +231,27 @@ ds_389::add { 'add_example_3':
 
 The following parameters are available in the `ds_389::add` defined type:
 
-* [`content`](#content)
-* [`group`](#group)
-* [`protocol`](#protocol)
-* [`root_dn_pass`](#root_dn_pass)
-* [`root_dn`](#root_dn)
-* [`server_host`](#server_host)
-* [`server_id`](#server_id)
-* [`server_port`](#server_port)
-* [`source`](#source)
-* [`starttls`](#starttls)
-* [`user`](#user)
+* [`content`](#-ds_389--add--content)
+* [`group`](#-ds_389--add--group)
+* [`protocol`](#-ds_389--add--protocol)
+* [`root_dn_pass`](#-ds_389--add--root_dn_pass)
+* [`root_dn`](#-ds_389--add--root_dn)
+* [`server_host`](#-ds_389--add--server_host)
+* [`server_id`](#-ds_389--add--server_id)
+* [`server_port`](#-ds_389--add--server_port)
+* [`source`](#-ds_389--add--source)
+* [`starttls`](#-ds_389--add--starttls)
+* [`user`](#-ds_389--add--user)
 
-##### <a name="content"></a>`content`
+##### <a name="-ds_389--add--content"></a>`content`
 
 Data type: `Optional[String]`
 
 The content value to use for the ldif file. Required, unless providing the source.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="group"></a>`group`
+##### <a name="-ds_389--add--group"></a>`group`
 
 Data type: `String`
 
@@ -259,7 +259,7 @@ The group of the created ldif file. Default: `$ds_389::group`
 
 Default value: `$ds_389::group`
 
-##### <a name="protocol"></a>`protocol`
+##### <a name="-ds_389--add--protocol"></a>`protocol`
 
 Data type: `Enum['ldap','ldaps']`
 
@@ -267,19 +267,19 @@ The protocol to use when calling ldapadd. Default: 'ldap'
 
 Default value: `'ldap'`
 
-##### <a name="root_dn_pass"></a>`root_dn_pass`
+##### <a name="-ds_389--add--root_dn_pass"></a>`root_dn_pass`
 
 Data type: `Variant[String,Sensitive[String]]`
 
 The password to use when calling ldapadd. Required.
 
-##### <a name="root_dn"></a>`root_dn`
+##### <a name="-ds_389--add--root_dn"></a>`root_dn`
 
 Data type: `String`
 
 The bind DN to use when calling ldapadd. Required.
 
-##### <a name="server_host"></a>`server_host`
+##### <a name="-ds_389--add--server_host"></a>`server_host`
 
 Data type: `String`
 
@@ -287,13 +287,13 @@ The host to use when calling ldapadd. Default: `$facts['networking']['fqdn']`
 
 Default value: `$facts['networking']['fqdn']`
 
-##### <a name="server_id"></a>`server_id`
+##### <a name="-ds_389--add--server_id"></a>`server_id`
 
 Data type: `String`
 
 The 389 ds instance name. Required.
 
-##### <a name="server_port"></a>`server_port`
+##### <a name="-ds_389--add--server_port"></a>`server_port`
 
 Data type: `Integer`
 
@@ -301,23 +301,23 @@ The port to use when calling ldapadd. Default: 389
 
 Default value: `389`
 
-##### <a name="source"></a>`source`
+##### <a name="-ds_389--add--source"></a>`source`
 
 Data type: `Optional[String]`
 
 The source path to use for the ldif file. Required, unless providing the content.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="starttls"></a>`starttls`
+##### <a name="-ds_389--add--starttls"></a>`starttls`
 
 Data type: `Boolean`
 
 Whether to use StartTLS when calling ldapadd. Default: false
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="user"></a>`user`
+##### <a name="-ds_389--add--user"></a>`user`
 
 Data type: `String`
 
@@ -325,7 +325,7 @@ The owner of the created ldif file. Default: `$ds_389::user`
 
 Default value: `$ds_389::user`
 
-### <a name="ds_389backup"></a>`ds_389::backup`
+### <a name="ds_389--backup"></a>`ds_389::backup`
 
 Setup backup jobs for a 389 ds instance.
 
@@ -345,29 +345,29 @@ ds_389::backup { 'daily backup':
 
 The following parameters are available in the `ds_389::backup` defined type:
 
-* [`backup_dir`](#backup_dir)
-* [`ensure`](#ensure)
-* [`environment`](#environment)
-* [`protocol`](#protocol)
-* [`root_dn_pass`](#root_dn_pass)
-* [`root_dn`](#root_dn)
-* [`rotate`](#rotate)
-* [`time`](#time)
-* [`server_host`](#server_host)
-* [`server_id`](#server_id)
-* [`server_port`](#server_port)
-* [`success_file`](#success_file)
+* [`backup_dir`](#-ds_389--backup--backup_dir)
+* [`ensure`](#-ds_389--backup--ensure)
+* [`environment`](#-ds_389--backup--environment)
+* [`protocol`](#-ds_389--backup--protocol)
+* [`root_dn_pass`](#-ds_389--backup--root_dn_pass)
+* [`root_dn`](#-ds_389--backup--root_dn)
+* [`rotate`](#-ds_389--backup--rotate)
+* [`time`](#-ds_389--backup--time)
+* [`server_host`](#-ds_389--backup--server_host)
+* [`server_id`](#-ds_389--backup--server_id)
+* [`server_port`](#-ds_389--backup--server_port)
+* [`success_file`](#-ds_389--backup--success_file)
 
-##### <a name="backup_dir"></a>`backup_dir`
+##### <a name="-ds_389--backup--backup_dir"></a>`backup_dir`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
 The directory where the backup files will be stored. The directory must
 be read- and writable for the 389-ds user. Default: `/var/lib/dirsrv/slapd-instance/bak`
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-ds_389--backup--ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -376,7 +376,7 @@ or removed (`absent`).
 
 Default value: `'present'`
 
-##### <a name="environment"></a>`environment`
+##### <a name="-ds_389--backup--environment"></a>`environment`
 
 Data type: `Array`
 
@@ -385,7 +385,7 @@ PATH variable is automatically added to the environment.
 
 Default value: `[]`
 
-##### <a name="protocol"></a>`protocol`
+##### <a name="-ds_389--backup--protocol"></a>`protocol`
 
 Data type: `Enum['ldap','ldaps']`
 
@@ -393,19 +393,19 @@ The protocol to use when performing the backup.
 
 Default value: `'ldaps'`
 
-##### <a name="root_dn_pass"></a>`root_dn_pass`
+##### <a name="-ds_389--backup--root_dn_pass"></a>`root_dn_pass`
 
 Data type: `Variant[String,Sensitive[String]]`
 
 The password to use when performing the backup. Required.
 
-##### <a name="root_dn"></a>`root_dn`
+##### <a name="-ds_389--backup--root_dn"></a>`root_dn`
 
 Data type: `String`
 
 The bind DN to use when performing the backup. Required.
 
-##### <a name="rotate"></a>`rotate`
+##### <a name="-ds_389--backup--rotate"></a>`rotate`
 
 Data type: `Integer`
 
@@ -413,7 +413,7 @@ The maximum backup age in days. Older backups will be removed.
 
 Default value: `30`
 
-##### <a name="time"></a>`time`
+##### <a name="-ds_389--backup--time"></a>`time`
 
 Data type: `Array`
 
@@ -421,7 +421,7 @@ An array containing the cron schedule in this order: minute, hour, weekday.
 
 Default value: `['15', '23', '*']`
 
-##### <a name="server_host"></a>`server_host`
+##### <a name="-ds_389--backup--server_host"></a>`server_host`
 
 Data type: `String`
 
@@ -429,13 +429,13 @@ The host to use when performing the backup. Default: `$facts['networking']['fqdn
 
 Default value: `$facts['networking']['fqdn']`
 
-##### <a name="server_id"></a>`server_id`
+##### <a name="-ds_389--backup--server_id"></a>`server_id`
 
 Data type: `String`
 
 The 389 ds instance name. Required.
 
-##### <a name="server_port"></a>`server_port`
+##### <a name="-ds_389--backup--server_port"></a>`server_port`
 
 Data type: `Integer`
 
@@ -443,7 +443,7 @@ The port to use when performing the backup. Default: 636
 
 Default value: `636`
 
-##### <a name="success_file"></a>`success_file`
+##### <a name="-ds_389--backup--success_file"></a>`success_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -451,7 +451,7 @@ Specify a path where upon successful backup a file should be created for checkin
 
 Default value: `'/tmp/389ds_backup_success'`
 
-### <a name="ds_389instance"></a>`ds_389::instance`
+### <a name="ds_389--instance"></a>`ds_389::instance`
 
 Manages a 389 ds instance.
 
@@ -473,77 +473,86 @@ ds_389::instance { 'foo':
 
 The following parameters are available in the `ds_389::instance` defined type:
 
-* [`add_ldifs`](#add_ldifs)
-* [`backup_enable`](#backup_enable)
-* [`backup_notls`](#backup_notls)
-* [`base_load_ldifs`](#base_load_ldifs)
-* [`cert_db_pass`](#cert_db_pass)
-* [`create_suffix`](#create_suffix)
-* [`group`](#group)
-* [`minssf`](#minssf)
-* [`modify_ldifs`](#modify_ldifs)
-* [`plugins`](#plugins)
-* [`replication`](#replication)
-* [`root_dn_pass`](#root_dn_pass)
-* [`root_dn`](#root_dn)
-* [`schema_extensions`](#schema_extensions)
-* [`server_host`](#server_host)
-* [`server_id`](#server_id)
-* [`server_port`](#server_port)
-* [`server_ssl_port`](#server_ssl_port)
-* [`ssl`](#ssl)
-* [`ssl_version_min`](#ssl_version_min)
-* [`subject_alt_names`](#subject_alt_names)
-* [`suffix`](#suffix)
-* [`user`](#user)
+* [`add_ldifs`](#-ds_389--instance--add_ldifs)
+* [`backup_enable`](#-ds_389--instance--backup_enable)
+* [`backup_notls`](#-ds_389--instance--backup_notls)
+* [`base_load_ldifs`](#-ds_389--instance--base_load_ldifs)
+* [`cert_db_pass`](#-ds_389--instance--cert_db_pass)
+* [`create_suffix`](#-ds_389--instance--create_suffix)
+* [`internal_token`](#-ds_389--instance--internal_token)
+* [`group`](#-ds_389--instance--group)
+* [`minssf`](#-ds_389--instance--minssf)
+* [`modify_ldifs`](#-ds_389--instance--modify_ldifs)
+* [`plugins`](#-ds_389--instance--plugins)
+* [`replication`](#-ds_389--instance--replication)
+* [`root_dn_pass`](#-ds_389--instance--root_dn_pass)
+* [`root_dn`](#-ds_389--instance--root_dn)
+* [`schema_extensions`](#-ds_389--instance--schema_extensions)
+* [`server_host`](#-ds_389--instance--server_host)
+* [`server_id`](#-ds_389--instance--server_id)
+* [`server_port`](#-ds_389--instance--server_port)
+* [`server_ssl_port`](#-ds_389--instance--server_ssl_port)
+* [`ssl`](#-ds_389--instance--ssl)
+* [`ssl_version_min`](#-ds_389--instance--ssl_version_min)
+* [`subject_alt_names`](#-ds_389--instance--subject_alt_names)
+* [`suffix`](#-ds_389--instance--suffix)
+* [`user`](#-ds_389--instance--user)
 
-##### <a name="add_ldifs"></a>`add_ldifs`
+##### <a name="-ds_389--instance--add_ldifs"></a>`add_ldifs`
 
 Data type: `Optional[Hash]`
 
 A hash of ldif add files. See add.pp. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="backup_enable"></a>`backup_enable`
+##### <a name="-ds_389--instance--backup_enable"></a>`backup_enable`
 
 Data type: `Boolean`
 
 Whether to enable a periodic backup job for this instance.
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="backup_notls"></a>`backup_notls`
+##### <a name="-ds_389--instance--backup_notls"></a>`backup_notls`
 
 Data type: `Boolean`
 
 Whether to disable TLS connection for the backup job.
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="base_load_ldifs"></a>`base_load_ldifs`
+##### <a name="-ds_389--instance--base_load_ldifs"></a>`base_load_ldifs`
 
 Data type: `Optional[Hash]`
 
 A hash of ldif add files to load after all other config files have been added. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="cert_db_pass"></a>`cert_db_pass`
+##### <a name="-ds_389--instance--cert_db_pass"></a>`cert_db_pass`
 
 Data type: `Variant[String,Sensitive[String]]`
 
-The certificate db password to ensure. Required.
+The certificate db password to ensure. Used to encrypt the p12 file.
 
-##### <a name="create_suffix"></a>`create_suffix`
+##### <a name="-ds_389--instance--create_suffix"></a>`create_suffix`
 
 Data type: `Boolean`
 
 Set this parameter to `True` to create a generic root node entry for the suffix in the database.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="group"></a>`group`
+##### <a name="-ds_389--instance--internal_token"></a>`internal_token`
+
+Data type: `Variant[String,Sensitive[String]]`
+
+Set the internal (software) token to be use to decrypt the NSS certificate database inside the p12 file during startup.
+
+Default value: `$root_dn_pass`
+
+##### <a name="-ds_389--instance--group"></a>`group`
 
 Data type: `String`
 
@@ -551,7 +560,7 @@ The group for the instance. Default: `$ds_389::group`
 
 Default value: `$ds_389::group`
 
-##### <a name="minssf"></a>`minssf`
+##### <a name="-ds_389--instance--minssf"></a>`minssf`
 
 Data type: `Integer`
 
@@ -559,51 +568,51 @@ The minimum security strength for connections. Default: 0
 
 Default value: `0`
 
-##### <a name="modify_ldifs"></a>`modify_ldifs`
+##### <a name="-ds_389--instance--modify_ldifs"></a>`modify_ldifs`
 
 Data type: `Optional[Hash]`
 
 A hash of ldif modify files. See modify.pp. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="plugins"></a>`plugins`
+##### <a name="-ds_389--instance--plugins"></a>`plugins`
 
 Data type: `Optional[Hash]`
 
 A hash of plugins to enable or disable. See plugin.pp. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="replication"></a>`replication`
+##### <a name="-ds_389--instance--replication"></a>`replication`
 
 Data type: `Optional[Hash]`
 
 A replication config hash. See replication.pp. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="root_dn_pass"></a>`root_dn_pass`
+##### <a name="-ds_389--instance--root_dn_pass"></a>`root_dn_pass`
 
 Data type: `Variant[String,Sensitive[String]]`
 
 The root dn password to ensure. Required.
 
-##### <a name="root_dn"></a>`root_dn`
+##### <a name="-ds_389--instance--root_dn"></a>`root_dn`
 
 Data type: `String`
 
 The root dn to ensure. Required.
 
-##### <a name="schema_extensions"></a>`schema_extensions`
+##### <a name="-ds_389--instance--schema_extensions"></a>`schema_extensions`
 
 Data type: `Optional[Hash]`
 
 A hash of schemas to ensure. See schema.pp. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="server_host"></a>`server_host`
+##### <a name="-ds_389--instance--server_host"></a>`server_host`
 
 Data type: `String`
 
@@ -611,7 +620,7 @@ The fqdn for the instance. Default: `$facts['networking']['fqdn']`
 
 Default value: `$facts['networking']['fqdn']`
 
-##### <a name="server_id"></a>`server_id`
+##### <a name="-ds_389--instance--server_id"></a>`server_id`
 
 Data type: `String`
 
@@ -619,7 +628,7 @@ The server identifier for the instance. Default: `$facts['networking']['hostname
 
 Default value: `$facts['networking']['hostname']`
 
-##### <a name="server_port"></a>`server_port`
+##### <a name="-ds_389--instance--server_port"></a>`server_port`
 
 Data type: `Integer`
 
@@ -627,7 +636,7 @@ The port to use for non-SSL traffic. Default: 389
 
 Default value: `389`
 
-##### <a name="server_ssl_port"></a>`server_ssl_port`
+##### <a name="-ds_389--instance--server_ssl_port"></a>`server_ssl_port`
 
 Data type: `Integer`
 
@@ -635,37 +644,37 @@ The port to use for SSL traffic. Default: 636
 
 Default value: `636`
 
-##### <a name="ssl"></a>`ssl`
+##### <a name="-ds_389--instance--ssl"></a>`ssl`
 
 Data type: `Optional[Hash]`
 
 An ssl config hash. See ssl.pp. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="ssl_version_min"></a>`ssl_version_min`
+##### <a name="-ds_389--instance--ssl_version_min"></a>`ssl_version_min`
 
 Data type: `Optional[String]`
 
 The minimum TLS version the instance should support. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="subject_alt_names"></a>`subject_alt_names`
+##### <a name="-ds_389--instance--subject_alt_names"></a>`subject_alt_names`
 
 Data type: `Optional[Array]`
 
 An array of subject alt names, if using self-signed certificates. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="suffix"></a>`suffix`
+##### <a name="-ds_389--instance--suffix"></a>`suffix`
 
 Data type: `String`
 
 The LDAP suffix to use. Required.
 
-##### <a name="user"></a>`user`
+##### <a name="-ds_389--instance--user"></a>`user`
 
 Data type: `String`
 
@@ -673,7 +682,7 @@ The user for the instance. Default: $ds_389::user
 
 Default value: `$ds_389::user`
 
-### <a name="ds_389modify"></a>`ds_389::modify`
+### <a name="ds_389--modify"></a>`ds_389::modify`
 
 Adds an ldif modify file to a 389 ds instance.
 
@@ -720,27 +729,27 @@ ds_389::modify { 'modify_example_3':
 
 The following parameters are available in the `ds_389::modify` defined type:
 
-* [`content`](#content)
-* [`group`](#group)
-* [`protocol`](#protocol)
-* [`root_dn_pass`](#root_dn_pass)
-* [`root_dn`](#root_dn)
-* [`server_host`](#server_host)
-* [`server_id`](#server_id)
-* [`server_port`](#server_port)
-* [`source`](#source)
-* [`starttls`](#starttls)
-* [`user`](#user)
+* [`content`](#-ds_389--modify--content)
+* [`group`](#-ds_389--modify--group)
+* [`protocol`](#-ds_389--modify--protocol)
+* [`root_dn_pass`](#-ds_389--modify--root_dn_pass)
+* [`root_dn`](#-ds_389--modify--root_dn)
+* [`server_host`](#-ds_389--modify--server_host)
+* [`server_id`](#-ds_389--modify--server_id)
+* [`server_port`](#-ds_389--modify--server_port)
+* [`source`](#-ds_389--modify--source)
+* [`starttls`](#-ds_389--modify--starttls)
+* [`user`](#-ds_389--modify--user)
 
-##### <a name="content"></a>`content`
+##### <a name="-ds_389--modify--content"></a>`content`
 
 Data type: `Optional[String]`
 
 The content value to use for the ldif file. Required, unless providing the source.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="group"></a>`group`
+##### <a name="-ds_389--modify--group"></a>`group`
 
 Data type: `String`
 
@@ -748,7 +757,7 @@ The group of the created ldif file. Default: `$ds_389::group`
 
 Default value: `$ds_389::group`
 
-##### <a name="protocol"></a>`protocol`
+##### <a name="-ds_389--modify--protocol"></a>`protocol`
 
 Data type: `Enum['ldap','ldaps']`
 
@@ -756,19 +765,19 @@ The protocol to use when calling ldapmodify. Default: 'ldap'
 
 Default value: `'ldap'`
 
-##### <a name="root_dn_pass"></a>`root_dn_pass`
+##### <a name="-ds_389--modify--root_dn_pass"></a>`root_dn_pass`
 
 Data type: `Variant[String,Sensitive[String]]`
 
 The password to use when calling ldapmodify. Required.
 
-##### <a name="root_dn"></a>`root_dn`
+##### <a name="-ds_389--modify--root_dn"></a>`root_dn`
 
 Data type: `String`
 
 The bind DN to use when calling ldapmodify. Required.
 
-##### <a name="server_host"></a>`server_host`
+##### <a name="-ds_389--modify--server_host"></a>`server_host`
 
 Data type: `String`
 
@@ -776,13 +785,13 @@ The host to use when calling ldapmodify. Default: `$facts['networking']['fqdn']`
 
 Default value: `$facts['networking']['fqdn']`
 
-##### <a name="server_id"></a>`server_id`
+##### <a name="-ds_389--modify--server_id"></a>`server_id`
 
 Data type: `String`
 
 The 389 ds instance name. Required.
 
-##### <a name="server_port"></a>`server_port`
+##### <a name="-ds_389--modify--server_port"></a>`server_port`
 
 Data type: `Integer`
 
@@ -790,23 +799,23 @@ The port to use when calling ldapmodify. Default: 389
 
 Default value: `389`
 
-##### <a name="source"></a>`source`
+##### <a name="-ds_389--modify--source"></a>`source`
 
 Data type: `Optional[String]`
 
 The source path to use for the ldif file. Required, unless providing the content.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="starttls"></a>`starttls`
+##### <a name="-ds_389--modify--starttls"></a>`starttls`
 
 Data type: `Boolean`
 
 Whether to use StartTLS when calling ldapmodify. Default: false
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="user"></a>`user`
+##### <a name="-ds_389--modify--user"></a>`user`
 
 Data type: `String`
 
@@ -814,7 +823,7 @@ The owner of the created ldif file. Default: `$ds_389::user`
 
 Default value: `$ds_389::user`
 
-### <a name="ds_389plugin"></a>`ds_389::plugin`
+### <a name="ds_389--plugin"></a>`ds_389::plugin`
 
 Manages a plugin for a 389 ds instance.
 
@@ -847,16 +856,16 @@ ds_389::plugin { 'memberof':
 
 The following parameters are available in the `ds_389::plugin` defined type:
 
-* [`ensure`](#ensure)
-* [`options`](#options)
-* [`protocol`](#protocol)
-* [`root_dn_pass`](#root_dn_pass)
-* [`root_dn`](#root_dn)
-* [`server_host`](#server_host)
-* [`server_id`](#server_id)
-* [`server_port`](#server_port)
+* [`ensure`](#-ds_389--plugin--ensure)
+* [`options`](#-ds_389--plugin--options)
+* [`protocol`](#-ds_389--plugin--protocol)
+* [`root_dn_pass`](#-ds_389--plugin--root_dn_pass)
+* [`root_dn`](#-ds_389--plugin--root_dn)
+* [`server_host`](#-ds_389--plugin--server_host)
+* [`server_id`](#-ds_389--plugin--server_id)
+* [`server_port`](#-ds_389--plugin--server_port)
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-ds_389--plugin--ensure"></a>`ensure`
 
 Data type: `Enum['enabled','disabled']`
 
@@ -864,7 +873,7 @@ The desired state of the plugin. Default: 'enabled'
 
 Default value: `'enabled'`
 
-##### <a name="options"></a>`options`
+##### <a name="-ds_389--plugin--options"></a>`options`
 
 Data type: `Array`
 
@@ -874,7 +883,7 @@ further attempts will fail. Optional.
 
 Default value: `[]`
 
-##### <a name="protocol"></a>`protocol`
+##### <a name="-ds_389--plugin--protocol"></a>`protocol`
 
 Data type: `Enum['ldap','ldaps']`
 
@@ -882,19 +891,19 @@ The protocol to use when calling ldapadd. Default: 'ldap'
 
 Default value: `'ldap'`
 
-##### <a name="root_dn_pass"></a>`root_dn_pass`
+##### <a name="-ds_389--plugin--root_dn_pass"></a>`root_dn_pass`
 
 Data type: `Variant[String,Sensitive[String]]`
 
 The password to use when calling ldapadd. Required.
 
-##### <a name="root_dn"></a>`root_dn`
+##### <a name="-ds_389--plugin--root_dn"></a>`root_dn`
 
 Data type: `String`
 
 The bind DN to use when calling ldapadd. Required.
 
-##### <a name="server_host"></a>`server_host`
+##### <a name="-ds_389--plugin--server_host"></a>`server_host`
 
 Data type: `String`
 
@@ -902,13 +911,13 @@ The host to use when calling ldapadd. Default: `$facts['networking']['fqdn']`
 
 Default value: `$facts['networking']['fqdn']`
 
-##### <a name="server_id"></a>`server_id`
+##### <a name="-ds_389--plugin--server_id"></a>`server_id`
 
 Data type: `String`
 
 The 389 ds instance name. Required.
 
-##### <a name="server_port"></a>`server_port`
+##### <a name="-ds_389--plugin--server_port"></a>`server_port`
 
 Data type: `Integer`
 
@@ -916,7 +925,7 @@ The port to use when calling ldapadd. Default: 389
 
 Default value: `389`
 
-### <a name="ds_389replication"></a>`ds_389::replication`
+### <a name="ds_389--replication"></a>`ds_389::replication`
 
 Sets up replication for a 389 ds instance.
 
@@ -974,57 +983,57 @@ ds_389::replication { 'supplier1':
 
 The following parameters are available in the `ds_389::replication` defined type:
 
-* [`bind_dn`](#bind_dn)
-* [`consumers`](#consumers)
-* [`excluded_attributes`](#excluded_attributes)
-* [`group`](#group)
-* [`hubs`](#hubs)
-* [`id`](#id)
-* [`init_consumers`](#init_consumers)
-* [`init_hubs`](#init_hubs)
-* [`init_suppliers`](#init_suppliers)
-* [`protocol`](#protocol)
-* [`purge_delay`](#purge_delay)
-* [`replica_port`](#replica_port)
-* [`replica_transport`](#replica_transport)
-* [`replication_pass`](#replication_pass)
-* [`replication_user`](#replication_user)
-* [`role`](#role)
-* [`root_dn_pass`](#root_dn_pass)
-* [`root_dn`](#root_dn)
-* [`server_host`](#server_host)
-* [`server_port`](#server_port)
-* [`starttls`](#starttls)
-* [`suffix`](#suffix)
-* [`supplier_role_name`](#supplier_role_name)
-* [`suppliers`](#suppliers)
-* [`user`](#user)
+* [`bind_dn`](#-ds_389--replication--bind_dn)
+* [`consumers`](#-ds_389--replication--consumers)
+* [`excluded_attributes`](#-ds_389--replication--excluded_attributes)
+* [`group`](#-ds_389--replication--group)
+* [`hubs`](#-ds_389--replication--hubs)
+* [`id`](#-ds_389--replication--id)
+* [`init_consumers`](#-ds_389--replication--init_consumers)
+* [`init_hubs`](#-ds_389--replication--init_hubs)
+* [`init_suppliers`](#-ds_389--replication--init_suppliers)
+* [`protocol`](#-ds_389--replication--protocol)
+* [`purge_delay`](#-ds_389--replication--purge_delay)
+* [`replica_port`](#-ds_389--replication--replica_port)
+* [`replica_transport`](#-ds_389--replication--replica_transport)
+* [`replication_pass`](#-ds_389--replication--replication_pass)
+* [`replication_user`](#-ds_389--replication--replication_user)
+* [`role`](#-ds_389--replication--role)
+* [`root_dn_pass`](#-ds_389--replication--root_dn_pass)
+* [`root_dn`](#-ds_389--replication--root_dn)
+* [`server_host`](#-ds_389--replication--server_host)
+* [`server_port`](#-ds_389--replication--server_port)
+* [`starttls`](#-ds_389--replication--starttls)
+* [`suffix`](#-ds_389--replication--suffix)
+* [`supplier_role_name`](#-ds_389--replication--supplier_role_name)
+* [`suppliers`](#-ds_389--replication--suppliers)
+* [`user`](#-ds_389--replication--user)
 
-##### <a name="bind_dn"></a>`bind_dn`
+##### <a name="-ds_389--replication--bind_dn"></a>`bind_dn`
 
 Data type: `Optional[String]`
 
 The bind dn of the replication user. Required.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="consumers"></a>`consumers`
+##### <a name="-ds_389--replication--consumers"></a>`consumers`
 
 Data type: `Optional[Array]`
 
 An array of consumer names to ensure. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="excluded_attributes"></a>`excluded_attributes`
+##### <a name="-ds_389--replication--excluded_attributes"></a>`excluded_attributes`
 
 Data type: `Optional[Array]`
 
 An array of attributes to exclude from replication. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="group"></a>`group`
+##### <a name="-ds_389--replication--group"></a>`group`
 
 Data type: `String`
 
@@ -1032,47 +1041,47 @@ The group of the created ldif file. Default: $ds_389::group
 
 Default value: `$ds_389::group`
 
-##### <a name="hubs"></a>`hubs`
+##### <a name="-ds_389--replication--hubs"></a>`hubs`
 
 Data type: `Optional[Array]`
 
 An array of hub names to ensure. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="id"></a>`id`
+##### <a name="-ds_389--replication--id"></a>`id`
 
 Data type: `Optional[Integer]`
 
 The replica id. Optional unless declaring a supplier.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="init_consumers"></a>`init_consumers`
+##### <a name="-ds_389--replication--init_consumers"></a>`init_consumers`
 
 Data type: `Boolean`
 
 Whether to initialize replication for consumers. Default: false
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="init_hubs"></a>`init_hubs`
+##### <a name="-ds_389--replication--init_hubs"></a>`init_hubs`
 
 Data type: `Boolean`
 
 Whether to initialize replication for hubs. Default: false
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="init_suppliers"></a>`init_suppliers`
+##### <a name="-ds_389--replication--init_suppliers"></a>`init_suppliers`
 
 Data type: `Boolean`
 
 Whether to initialize replication for suppliers. Default: false
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="protocol"></a>`protocol`
+##### <a name="-ds_389--replication--protocol"></a>`protocol`
 
 Data type: `Enum['ldap','ldaps']`
 
@@ -1080,7 +1089,7 @@ The protocol to use when calling ldapmodify. Default: 'ldap'
 
 Default value: `'ldap'`
 
-##### <a name="purge_delay"></a>`purge_delay`
+##### <a name="-ds_389--replication--purge_delay"></a>`purge_delay`
 
 Data type: `Integer`
 
@@ -1088,7 +1097,7 @@ Time in seconds state information stored in replica entries is retained. Default
 
 Default value: `604800`
 
-##### <a name="replica_port"></a>`replica_port`
+##### <a name="-ds_389--replication--replica_port"></a>`replica_port`
 
 Data type: `Integer`
 
@@ -1096,7 +1105,7 @@ The port to use for replication. Default: 389
 
 Default value: `389`
 
-##### <a name="replica_transport"></a>`replica_transport`
+##### <a name="-ds_389--replication--replica_transport"></a>`replica_transport`
 
 Data type: `Enum['LDAP','SSL','TLS','LDAPS','StartTLS']`
 
@@ -1104,13 +1113,13 @@ The transport type to use for replication. Default: 'LDAP'
 
 Default value: `'LDAP'`
 
-##### <a name="replication_pass"></a>`replication_pass`
+##### <a name="-ds_389--replication--replication_pass"></a>`replication_pass`
 
 Data type: `Variant[String,Sensitive[String]]`
 
 The password of the replication user. Required.
 
-##### <a name="replication_user"></a>`replication_user`
+##### <a name="-ds_389--replication--replication_user"></a>`replication_user`
 
 Data type: `String`
 
@@ -1118,25 +1127,25 @@ The user account to use for replication.
 
 Default value: `'Replication Manager'`
 
-##### <a name="role"></a>`role`
+##### <a name="-ds_389--replication--role"></a>`role`
 
 Data type: `Enum['supplier','hub','consumer']`
 
 Replication role. Either 'supplier', 'hub', or 'consumer'. Required.
 
-##### <a name="root_dn_pass"></a>`root_dn_pass`
+##### <a name="-ds_389--replication--root_dn_pass"></a>`root_dn_pass`
 
 Data type: `Variant[String,Sensitive[String]]`
 
 The root dn password for configuring replication. Required.
 
-##### <a name="root_dn"></a>`root_dn`
+##### <a name="-ds_389--replication--root_dn"></a>`root_dn`
 
 Data type: `String`
 
 The root dn for configuring replication. Required.
 
-##### <a name="server_host"></a>`server_host`
+##### <a name="-ds_389--replication--server_host"></a>`server_host`
 
 Data type: `String`
 
@@ -1144,7 +1153,7 @@ The host to use when calling ldapmodify. Default: $fqdn
 
 Default value: `$facts['networking']['fqdn']`
 
-##### <a name="server_port"></a>`server_port`
+##### <a name="-ds_389--replication--server_port"></a>`server_port`
 
 Data type: `Integer`
 
@@ -1152,21 +1161,21 @@ The port to use when calling ldapmodify. Default: 389
 
 Default value: `389`
 
-##### <a name="starttls"></a>`starttls`
+##### <a name="-ds_389--replication--starttls"></a>`starttls`
 
 Data type: `Boolean`
 
 Whether to use StartTLS when calling ldapmodify. Default: false
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="suffix"></a>`suffix`
+##### <a name="-ds_389--replication--suffix"></a>`suffix`
 
 Data type: `String`
 
 The LDAP suffix to use. Required.
 
-##### <a name="supplier_role_name"></a>`supplier_role_name`
+##### <a name="-ds_389--replication--supplier_role_name"></a>`supplier_role_name`
 
 Data type: `String`
 
@@ -1175,15 +1184,15 @@ In 389-ds the name of the supplier replication role was renamed from
 
 Default value: `$ds_389::supplier_role_name`
 
-##### <a name="suppliers"></a>`suppliers`
+##### <a name="-ds_389--replication--suppliers"></a>`suppliers`
 
 Data type: `Optional[Array]`
 
 An array of supplier names to ensure. Optional.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="user"></a>`user`
+##### <a name="-ds_389--replication--user"></a>`user`
 
 Data type: `String`
 
@@ -1191,7 +1200,7 @@ The owner of the created ldif file. Default: $ds_389::user
 
 Default value: `$ds_389::user`
 
-### <a name="ds_389schema"></a>`ds_389::schema`
+### <a name="ds_389--schema"></a>`ds_389::schema`
 
 Adds a schema extension ldif file to a 389 ds instance.
 
@@ -1210,12 +1219,12 @@ ds_389::schema { '50example':
 
 The following parameters are available in the `ds_389::schema` defined type:
 
-* [`group`](#group)
-* [`server_id`](#server_id)
-* [`source`](#source)
-* [`user`](#user)
+* [`group`](#-ds_389--schema--group)
+* [`server_id`](#-ds_389--schema--server_id)
+* [`source`](#-ds_389--schema--source)
+* [`user`](#-ds_389--schema--user)
 
-##### <a name="group"></a>`group`
+##### <a name="-ds_389--schema--group"></a>`group`
 
 Data type: `String`
 
@@ -1223,19 +1232,19 @@ The group of the created ldif file. Default: $ds_389::group
 
 Default value: `$ds_389::group`
 
-##### <a name="server_id"></a>`server_id`
+##### <a name="-ds_389--schema--server_id"></a>`server_id`
 
 Data type: `String`
 
 The 389 ds instance name. Required.
 
-##### <a name="source"></a>`source`
+##### <a name="-ds_389--schema--source"></a>`source`
 
 Data type: `String`
 
 The source path to use for the ldif file. Required.
 
-##### <a name="user"></a>`user`
+##### <a name="-ds_389--schema--user"></a>`user`
 
 Data type: `String`
 
@@ -1243,7 +1252,7 @@ The owner of the created ldif file. Default: $ds_389::user
 
 Default value: `$ds_389::user`
 
-### <a name="ds_389service"></a>`ds_389::service`
+### <a name="ds_389--service"></a>`ds_389::service`
 
 Manages the service for a 389 ds instance.
 
@@ -1251,18 +1260,18 @@ Manages the service for a 389 ds instance.
 
 The following parameters are available in the `ds_389::service` defined type:
 
-* [`service_enable`](#service_enable)
-* [`service_ensure`](#service_ensure)
+* [`service_enable`](#-ds_389--service--service_enable)
+* [`service_ensure`](#-ds_389--service--service_ensure)
 
-##### <a name="service_enable"></a>`service_enable`
+##### <a name="-ds_389--service--service_enable"></a>`service_enable`
 
 Data type: `Boolean`
 
 Whether the service should be enabled. Default: true
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="service_ensure"></a>`service_ensure`
+##### <a name="-ds_389--service--service_ensure"></a>`service_ensure`
 
 Data type: `String`
 
@@ -1270,7 +1279,7 @@ The state the service should be in. Default: 'running'
 
 Default value: `'running'`
 
-### <a name="ds_389ssl"></a>`ds_389::ssl`
+### <a name="ds_389--ssl"></a>`ds_389::ssl`
 
 Manages SSL for a 389 ds instance.
 
@@ -1290,24 +1299,24 @@ ds_389::ssl { 'foo':
 
 The following parameters are available in the `ds_389::ssl` defined type:
 
-* [`cert_name`](#cert_name)
-* [`group`](#group)
-* [`minssf`](#minssf)
-* [`root_dn_pass`](#root_dn_pass)
-* [`root_dn`](#root_dn)
-* [`server_host`](#server_host)
-* [`server_port`](#server_port)
-* [`server_ssl_port`](#server_ssl_port)
-* [`ssl_version_min`](#ssl_version_min)
-* [`user`](#user)
+* [`cert_name`](#-ds_389--ssl--cert_name)
+* [`group`](#-ds_389--ssl--group)
+* [`minssf`](#-ds_389--ssl--minssf)
+* [`root_dn_pass`](#-ds_389--ssl--root_dn_pass)
+* [`root_dn`](#-ds_389--ssl--root_dn)
+* [`server_host`](#-ds_389--ssl--server_host)
+* [`server_port`](#-ds_389--ssl--server_port)
+* [`server_ssl_port`](#-ds_389--ssl--server_ssl_port)
+* [`ssl_version_min`](#-ds_389--ssl--ssl_version_min)
+* [`user`](#-ds_389--ssl--user)
 
-##### <a name="cert_name"></a>`cert_name`
+##### <a name="-ds_389--ssl--cert_name"></a>`cert_name`
 
 Data type: `String`
 
 The nickname of the SSL cert to use. Required.
 
-##### <a name="group"></a>`group`
+##### <a name="-ds_389--ssl--group"></a>`group`
 
 Data type: `String`
 
@@ -1315,7 +1324,7 @@ The group of the created ldif file. Default: $ds_389::group
 
 Default value: `$ds_389::group`
 
-##### <a name="minssf"></a>`minssf`
+##### <a name="-ds_389--ssl--minssf"></a>`minssf`
 
 Data type: `Integer`
 
@@ -1323,19 +1332,19 @@ The minimum security strength for connections. Default: 0
 
 Default value: `0`
 
-##### <a name="root_dn_pass"></a>`root_dn_pass`
+##### <a name="-ds_389--ssl--root_dn_pass"></a>`root_dn_pass`
 
 Data type: `Variant[String,Sensitive[String]]`
 
 The password to use when calling ldapmodify. Required.
 
-##### <a name="root_dn"></a>`root_dn`
+##### <a name="-ds_389--ssl--root_dn"></a>`root_dn`
 
 Data type: `String`
 
 The bind DN to use when calling ldapmodify. Required.
 
-##### <a name="server_host"></a>`server_host`
+##### <a name="-ds_389--ssl--server_host"></a>`server_host`
 
 Data type: `String`
 
@@ -1343,7 +1352,7 @@ The host to use when calling ldapmodify. Default: `$facts['networking']['fqdn']`
 
 Default value: `$facts['networking']['fqdn']`
 
-##### <a name="server_port"></a>`server_port`
+##### <a name="-ds_389--ssl--server_port"></a>`server_port`
 
 Data type: `Integer`
 
@@ -1351,7 +1360,7 @@ The port to use when calling ldapmodify. Default: 389
 
 Default value: `389`
 
-##### <a name="server_ssl_port"></a>`server_ssl_port`
+##### <a name="-ds_389--ssl--server_ssl_port"></a>`server_ssl_port`
 
 Data type: `Integer`
 
@@ -1359,7 +1368,7 @@ The port to use for SSL traffic. Default: 636
 
 Default value: `636`
 
-##### <a name="ssl_version_min"></a>`ssl_version_min`
+##### <a name="-ds_389--ssl--ssl_version_min"></a>`ssl_version_min`
 
 Data type: `String`
 
@@ -1367,7 +1376,7 @@ The minimum TLS version to allow. Default: 'TLS1.1'
 
 Default value: `'TLS1.1'`
 
-##### <a name="user"></a>`user`
+##### <a name="-ds_389--ssl--user"></a>`user`
 
 Data type: `String`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,31 +80,12 @@ class ds_389 (
   Optional[String] $dnf_module_name = undef,
   Optional[String] $dnf_module_version = undef,
 ) {
-  class { 'ds_389::install': }
+  contain 'ds_389::install'
 
-  if $instances {
-    $instances.each |$instance_name, $params| {
-      ds_389::instance { $instance_name:
-        root_dn           => $params['root_dn'],
-        suffix            => $params['suffix'],
-        cert_db_pass      => $params['cert_db_pass'],
-        root_dn_pass      => $params['root_dn_pass'],
-        group             => $params['group'],
-        user              => $params['user'],
-        server_id         => $params['server_id'],
-        server_host       => $params['server_host'],
-        server_port       => $params['server_port'],
-        server_ssl_port   => $params['server_ssl_port'],
-        subject_alt_names => $params['subject_alt_names'],
-        replication       => $params['replication'],
-        ssl               => $params['ssl'],
-        ssl_version_min   => $params['ssl_version_min'],
-        schema_extensions => $params['schema_extensions'],
-        modify_ldifs      => $params['modify_ldifs'],
-        add_ldifs         => $params['add_ldifs'],
-        base_load_ldifs   => $params['base_load_ldifs'],
-        require           => Class['ds_389::install'],
-      }
+  $instances.each |$instance_name, $params| {
+    Class['ds_389::install']
+    -> ds_389::instance { $instance_name:
+      * => $params,
     }
   }
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -22,10 +22,13 @@
 #   A hash of ldif add files to load after all other config files have been added. Optional.
 #
 # @param cert_db_pass
-#   The certificate db password to ensure. Required.
+#   The certificate db password to ensure. Used to encrypt the p12 file.
 #
 # @param create_suffix
 #   Set this parameter to `True` to create a generic root node entry for the suffix in the database.
+#
+# @param internal_token
+#   Set the internal (software) token to be use to decrypt the NSS certificate database inside the p12 file during startup.
 #
 # @param group
 #   The group for the instance. Default: `$ds_389::group`
@@ -83,6 +86,7 @@ define ds_389::instance (
   String $root_dn,
   Variant[String,Sensitive[String]] $root_dn_pass,
   String $suffix,
+  Variant[String,Sensitive[String]] $internal_token = $root_dn_pass,
   Boolean $backup_enable = false,
   Boolean $backup_notls = false,
   Boolean $create_suffix = true,
@@ -163,7 +167,7 @@ define ds_389::instance (
     mode      => '0440',
     owner     => $user,
     group     => $group,
-    content   => "Internal (Software) Token:${root_dn_pass}\n",
+    content   => "Internal (Software) Token:${internal_token}\n",
     show_diff => false,
     require   => Exec["setup ds: ${server_id}"],
     notify    => Exec["restart ${server_id} to pick up new token"],
@@ -202,7 +206,7 @@ define ds_389::instance (
     }
 
     exec { "Create cert DB: ${server_id}":
-      command     => "pk12util -i ${ds_389::ssl_dir}/${server_id}.p12 -d ${instance_path} -W ${cert_db_pass} -K ${root_dn_pass}", # lint:ignore:140chars
+      command     => "pk12util -i ${ds_389::ssl_dir}/${server_id}.p12 -d ${instance_path} -W ${cert_db_pass} -K ${internal_token}", # lint:ignore:140chars
       path        => $ds_389::path,
       refreshonly => true,
       before      => Exec["Add trust for server cert: ${server_id}"],


### PR DESCRIPTION
Allow to set a different password for the NSS certificate database and the `root_dn_pass`.

This allows password retention / recovery of `root_dn_pass` as described in https://www.port389.org/docs/389ds/howto/howto-resetdirmgrpassword.html